### PR TITLE
Build and deploy project with hosting error

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,8 @@ def create_app():
     from .routes.api import api_bp
     from .routes.web import web
 
-    app.register_blueprint(api_bp, url_prefix='/api')
+    # `api_bp` already declares url_prefix='/api' internally
+    app.register_blueprint(api_bp)
     app.register_blueprint(web)
 
     return app

--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -30,7 +30,8 @@ def home():
                 # Read the generated file to show preview
                 try:
                     # The file should now be in ad_warn_data directory
-                    ad_warn_dir = os.path.join(os.getcwd(), 'ad_warn_data')
+                    is_serverless = os.environ.get('VERCEL') or os.environ.get('AWS_LAMBDA_FUNCTION_NAME')
+                    ad_warn_dir = '/tmp/ad_warn_data' if is_serverless else os.path.join(os.getcwd(), 'ad_warn_data')
                     file_path = os.path.join(ad_warn_dir, output_file)
                     with open(file_path, 'r', encoding='utf-8') as f:
                         file_content = f.read()
@@ -103,7 +104,8 @@ def bar_chart():
         
         if result.returncode == 0:
             # Check if the combined chart file was generated
-            chart_file = os.path.join(os.getcwd(), 'combined_accuracy_chart.html')
+            is_serverless = os.environ.get('VERCEL') or os.environ.get('AWS_LAMBDA_FUNCTION_NAME')
+            chart_file = os.path.join('/tmp', 'combined_accuracy_chart.html') if is_serverless else os.path.join(os.getcwd(), 'combined_accuracy_chart.html')
             if os.path.exists(chart_file):
                 return send_file(chart_file, mimetype='text/html')
             else:

--- a/combined_graph.py
+++ b/combined_graph.py
@@ -1,10 +1,13 @@
+import os
 import pandas as pd
 import plotly.graph_objects as go
 
 # 1. Load and process the data from the CSV file, skipping the title row
 try:
     # First, read the first line to extract month information
-    with open('./ad_warn_data/final_warning_report.csv', 'r') as f:
+    is_serverless = os.environ.get('VERCEL') or os.environ.get('AWS_LAMBDA_FUNCTION_NAME')
+    base_dir = '/tmp/ad_warn_data' if is_serverless else './ad_warn_data'
+    with open(f"{base_dir}/final_warning_report.csv", 'r') as f:
         first_line = f.readline().strip()
     
     # Extract month from the first line (e.g., "Aerodrome warning for station VABB for July 2025")
@@ -13,7 +16,7 @@ try:
     month_name = month_match.group(1) if month_match else "Unknown Month"
     
     # Now read the CSV data skipping the title row
-    df = pd.read_csv('./ad_warn_data/final_warning_report.csv', skiprows=1)
+    df = pd.read_csv(f"{base_dir}/final_warning_report.csv", skiprows=1)
 except FileNotFoundError:
     print("Error: 'final_warning_report.csv' not found. Please ensure the file is in the correct directory.")
     exit()
@@ -113,7 +116,8 @@ fig.update_layout(
 )
 
 # 6. Save the chart to a single HTML file
-fig.write_html("combined_accuracy_chart.html")
+output_html = "/tmp/combined_accuracy_chart.html" if is_serverless else "combined_accuracy_chart.html"
+fig.write_html(output_html)
 
-print("Successfully generated the HTML file: combined_accuracy_chart.html")
+print(f"Successfully generated the HTML file: {output_html}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ PyPDF2==3.0.1
 openpyxl==3.1.2
 reportlab==4.1.0
 Pillow>=10.0.0
+numpy==1.26.4
+plotly==5.22.0

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,14 @@
   "builds": [
     {
       "src": "run.py",
-      "use": "@vercel/python"
+      "use": "@vercel/python",
+      "config": {
+        "includeFiles": [
+          "app/templates/**",
+          "app/static/**",
+          "combined_graph.py"
+        ]
+      }
     }
   ],
   "routes": [


### PR DESCRIPTION
Ensure Vercel deployment success by adding missing dependencies, configuring file paths for serverless environments, and explicitly including all necessary assets.

The original deployment failed due to missing dependencies and Vercel's read-only filesystem limitations outside of `/tmp`. This PR addresses these by adding `plotly` and `numpy`, redirecting generated files to `/tmp`, and ensuring all templates, static files, and the plotting script are bundled via `vercel.json`. It also fixes a redundant URL prefix for the API blueprint.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0c40926-00ec-4a6b-aac4-b821360e7bac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0c40926-00ec-4a6b-aac4-b821360e7bac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

